### PR TITLE
Modify how allowed_torrents is checked, Fixes #3

### DIFF
--- a/pybtracker/server.py
+++ b/pybtracker/server.py
@@ -55,7 +55,7 @@ class UdpTrackerServerProto(asyncio.Protocol):
             # old. remove it and send an error.
             del self.server.connids[connid]
             return self.error(tid, 'Old connection identifier.'.encode('utf-8'))
-        elif len(self.allowed_torrents) > 0 and ih not in self.allowed_torrents:
+        elif self.allowed_torrents and ih not in self.allowed_torrents:
             return self.error(tid, 'Unknown/Forbidden torrent.'.encode('utf-8'))
         else:
             if ev == 0:


### PR DESCRIPTION
 Since allowed_torrents is by default a `NoneType`, checking `len()` over it can at times raise TypeError as in #3 